### PR TITLE
Fix typo: 'Infractructure' corrected to 'Infrastructure'.  

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Blobscan infra
 
-This repository contains Infractructure as Code (IaC) resources to deploy
+This repository contains Infrastructure as Code (IaC) resources to deploy
 and provision Blobscan.
 
 Uses [https://github.com/ethersphere/ansible-role-bee/](ansible-role-bee) among other [ansible requirements](ansible/requirements.yml).


### PR DESCRIPTION
<img width="345" alt="image" src="https://github.com/user-attachments/assets/61c5c4ed-2fee-4221-b03f-424208e1f7c6">
